### PR TITLE
Fix quoting for custom extension_api.json

### DIFF
--- a/tools/run/RunMain.hx
+++ b/tools/run/RunMain.hx
@@ -163,7 +163,7 @@ ${REGULAR_TEXT}Flags:
       var args = ['build-bindings.hxml', '-D', 'output="$bindingDir"'];
       if (options.exists('extension-api-json')) {
          args.push('-D');
-         args.push('EXT_API_JSON="${options.get('extension-api-json')}"');
+         args.push('EXT_API_JSON=${options.get('extension-api-json')}');
       }
       run("", "haxe", args);
       File.saveContent(Path.join([bindingDir, '.gdignore']), '');


### PR DESCRIPTION
When passing a custom extension_api.json to the CLI in generate_bindings, the current code would add extra quotes around the supplied path, resulting in something like
`'"/home/user/extension_api.json"'`.

From my tests this seems to work correctly now. Paths with spaces also work. I could only get this to work with absolute paths, but that's better than not at all I guess.

Remember to regenerate the CLI binary (I didn't do that, but I can change the commit if you want me to).