### PR TITLE
Fix typo in example project

### DIFF
--- a/tools/template/test.gd
+++ b/tools/template/test.gd
@@ -24,7 +24,7 @@ func _ready():
 	print(bytes)
 
 	var strings = test_strings(PackedStringArray(["was", "geht"]))
-	print(string)
+	print(strings)
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):


### PR DESCRIPTION
There was a typo in the gdscript file copied from the example project preventing the project from running out of the box.