### PR TITLE
Clarify CLI options

### DIFF
--- a/tools/run/RunMain.hx
+++ b/tools/run/RunMain.hx
@@ -174,7 +174,7 @@ ${REGULAR_TEXT}Afterwards, you can open it in Godot 4 - Have fun! :)');
             });
          case 'help' | 'usage':
             log('\n${REGULAR_TEXT}Usage:
- ${COMMAND_TEXT}haxelib run hxgodot init
+ ${COMMAND_TEXT}haxelib run hxgodot init ${ALT_COMMAND_TEXT}[--extension-api-json=<path>]
   ${REGULAR_TEXT}1. Setup a sample project in the current working directory.
   2. Generate Godot 4 bindings in the current working directory.
 


### PR DESCRIPTION
**(Once again, I'm not sure if I generated `run.n` correctly as it's gotten much smaller(?) )**

The existing CLI help text didn't make it clear that `--extension-api-json` also works for `hxgodot init`. Added the optional `--extension-api-json` to the help text for the `init` command to make it clear it works for both `init` and `generate_bindings`.