### PR TITLE
Allow building for apple silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ When you are first starting out HxGodot is able to generate a simple example pro
 
 
  4. Build the extension according to your platform's flavor:
-   ```bash
-   scons platform=<windows|linux|macos> target=<debug|release>
-   ```
+    ```bash
+    scons platform=<windows|linux|macos> target=<debug|release> arch=<x86_64|x86_32|arm64>
+    ```
+   
+    Examples:
+    - for Apple Silicon: `scons platform=macos arch=arm64`
     
  5. Open the sample-project in Godot4. Please be aware, that you might need to restart the editor after the first start for everything to setup correctly:
 	 

--- a/tools/template/SConstruct
+++ b/tools/template/SConstruct
@@ -6,7 +6,7 @@ from SCons.Variables import *
 
 default_platform = "windows"
 platforms = ("windows", "linux", "macos")
-architecture_array = ["x86_64", "x86_32"]
+architecture_array = ["x86_64", "x86_32", "arm64"]
 haxe_target_array = ['cpp', 'cppia']
 
 opts = Variables([], ARGUMENTS)
@@ -91,6 +91,8 @@ elif env['platform'] == "macos":
 
     if env["arch"] == "x86_64":
         cc_flags.append('-m64')
+    elif env["arch"] == "arm64":
+        cc_flags.append('-m64')
     else:
         cc_flags.append('-m32')
 
@@ -116,6 +118,8 @@ else:
     hxCmd = hxCmd + ' -D HXCPP_GC_GENERATIONAL -D HXCPP_CPP11 -D static_link -cpp bin/ -cp bindings'
     if env["arch"] == "x86_64":
         hxCmd = hxCmd + ' -D HXCPP_M64'
+    elif env["arch"] == "arm64":
+        hxCmd = hxCmd + ' -D HXCPP_ARM64'
     if env["scriptable"] == True:
         hxCmd = hxCmd + ' -D scriptable'
 


### PR DESCRIPTION
Tested on my M1 and this allowed me to finish the "First time setup" section in the readme (the godot project can run the haxe-built extension successfully)